### PR TITLE
use standard import for node querystring

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "ts-lambda-local-dev",
-  "version": "1.3.0",
+  "version": "1.3.1",
   "description": "typescript lambda local development server",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -1,7 +1,7 @@
 import { Context } from 'aws-lambda';
 import { IncomingHttpHeaders, OutgoingHttpHeaders } from 'http';
 import { HTTPMethod } from 'http-method-enum';
-import { ParsedUrlQuery } from 'node:querystring';
+import { ParsedUrlQuery } from 'querystring';
 
 export interface RequestEvent {
   requestContext?: any;


### PR DESCRIPTION
getting
> node_modules/ts-lambda-local-dev/dist/types/index.d.ts(5,32): error TS2307: Cannot find module 'node:querystring' or its corresponding type declarations.

