### PR TITLE
add declarationMap for ide

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "ts-lambda-local-dev",
-  "version": "1.3.2",
+  "version": "1.3.3",
   "description": "typescript lambda local development server",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -7,6 +7,7 @@
     "experimentalDecorators": true,
     "esModuleInterop": true,
     "sourceMap": true,
+    "declarationMap": true,
     "strict": true,
     "strictPropertyInitialization": false,
     "lib": [


### PR DESCRIPTION
so that the `go to definition` can jump to the source file rather than the `d.ts` file