### PR TITLE
feat: handle duplicate query string parameters like APIGW

### DIFF
--- a/src/local.lambda.ts
+++ b/src/local.lambda.ts
@@ -3,6 +3,7 @@ import { Context } from 'aws-lambda';
 import * as url from 'url';
 import HTTPMethod from 'http-method-enum';
 import { LambdaHandler, RequestEvent } from './types';
+import { flattenArraysInJSON } from './utils';
 
 const DefaultPort = 8000;
 
@@ -54,7 +55,10 @@ export class LocalLambda {
           httpMethod: request.method as HTTPMethod,
           method: request.method,
           headers: request.headers,
-          queryStringParameters: parsedUrl.query as Record<string, string>,
+          /* if duplicate queryParameters are present then API Gateway will flatten them into a comma-separated list
+             eg: ?a=1&a=2&a=3 will be parsed as { a: [1,2,3] } by url.parse and flattenArraysInJSON will convert it to { a: '1,2,3' } which is the same behavior as API Gateway
+          */
+          queryStringParameters: flattenArraysInJSON(parsedUrl.query) as Record<string, string>,
           body: isBinaryUpload ? body.toString('base64') : body.toString('utf8'),
           isBase64Encoded: isBinaryUpload ? true : false,
         };

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -1,0 +1,13 @@
+export function flattenArraysInJSON(json: Record<string, any>): Record<string, any> {
+  const flattenedJson = json;
+  for (const [key, value] of Object.entries(json)) {
+    if (Array.isArray(value)) {
+      flattenedJson[key] = value.join(',');
+    } else if (typeof value === 'object' && value !== null) {
+      flattenedJson[key] = flattenArraysInJSON(value);
+    } else {
+      flattenedJson[key] = value;
+    }
+  }
+  return flattenedJson;
+}


### PR DESCRIPTION
This commit modifies the behavior of the LocalLambda class to convert any query string parameters that are arrays to comma-separated strings. This ensures that the query string parameters are in a format that is compatible with the API Gateway's integration request mapping template, which expects query string parameters to be strings.

if duplicate queryParameters are present then API Gateway will flatten them into a comma-separated list
eg: `?a=1&a=2&a=3` will be parsed as `{ a: [1,2,3] }` by url.parse and `flattenArraysInJSON` will convert it to `{ a: '1,2,3' }` which yields the same behavior demonstrated by API Gateway