### PR TITLE
feat: Introduce LocalLambdaGroup to manage multiple lambdas in a single server instance

### DIFF
--- a/src/example/multi.ts
+++ b/src/example/multi.ts
@@ -1,6 +1,6 @@
 import { Context } from 'aws-lambda';
-import { LocalLambdaGroupConfig, LambdaConfig, LocalLambdaGroup } from '../local.lambda';
 import { LambdaResponse, RequestEvent } from '../types';
+import { LambdaConfig, LocalLambdaGroupConfig, LocalLambdaGroup } from '../lambda.group';
 
 // handler is a function that takes in an event and context and returns a response
 const handler = async (req: RequestEvent, context: Context): Promise<LambdaResponse> => ({ statusCode: 200, body: `Hello World !!! My userId is ${req.pathParameters?.id}\n My JWT is ${JSON.stringify(req.requestContext.authorizer.lambda.jwt)}. My queryStringParameter is ${JSON.stringify(req.queryStringParameters)} ` });
@@ -51,5 +51,7 @@ const multiConfig: LocalLambdaGroupConfig = {
   port: 8008, // optional, default to 8000
   defaultPath: '/api/v1', // optional, default to '/'
 };
+
+// visit http://localhost:8008/user/1234567890 to see the response
 const localLambdaGroup = new LocalLambdaGroup(multiConfig);
 localLambdaGroup.run();

--- a/src/example/multi.ts
+++ b/src/example/multi.ts
@@ -1,0 +1,55 @@
+import { Context } from 'aws-lambda';
+import { LocalLambdaGroupConfig, LambdaConfig, LocalLambdaGroup } from '../local.lambda';
+import { LambdaResponse, RequestEvent } from '../types';
+
+// handler is a function that takes in an event and context and returns a response
+const handler = async (req: RequestEvent, context: Context): Promise<LambdaResponse> => ({ statusCode: 200, body: `Hello World !!! My userId is ${req.pathParameters?.id}\n My JWT is ${JSON.stringify(req.requestContext.authorizer.lambda.jwt)}. My queryStringParameter is ${JSON.stringify(req.queryStringParameters)} ` });
+const funnyHandler = async (req: RequestEvent, context: Context): Promise<LambdaResponse> => ({ statusCode: 200, body: `Hello World !!! I'm funny and my userId is ${req.pathParameters?.id}\n My JWT is ${JSON.stringify(req.requestContext.authorizer.lambda.jwt)}. My queryStringParameter is ${JSON.stringify(req.queryStringParameters)} ` });
+
+// context is provided as optional field in config.
+const config: LambdaConfig[] = [
+  {
+    handler: handler, // if type is not compatible, do `handler: handler as any`
+    requestContext: {
+      authorizer: {
+        lambda: {
+          jwt: {
+            claims: {
+              sub: '1234567890',
+              name: 'John Doe',
+              iat: 1516239022,
+            },
+            scopes: ['read', 'write'],
+          },
+        },
+      },
+    },
+    pathParamsPattern: '/user/:id', // optional, default to '/'
+  },
+  {
+    handler: funnyHandler, // if type is not compatible, do `handler: handler as any`
+    pathParamsPattern: '/user/:id/funny', // optional, default to '/'
+    requestContext: {
+      authorizer: {
+        lambda: {
+          jwt: {
+            claims: {
+              sub: '1234567890',
+              name: 'John Doe',
+              iat: 1516239022,
+            },
+            scopes: ['read', 'write'],
+          },
+        },
+      },
+    },
+  },
+];
+
+const multiConfig: LocalLambdaGroupConfig = {
+  lambdas: config,
+  port: 8008, // optional, default to 8000
+  defaultPath: '/api/v1', // optional, default to '/'
+};
+const localLambdaGroup = new LocalLambdaGroup(multiConfig);
+localLambdaGroup.run();

--- a/src/example/multi.ts
+++ b/src/example/multi.ts
@@ -52,6 +52,6 @@ const multiConfig: LocalLambdaGroupConfig = {
   defaultPath: '/api/v1', // optional, default to '/'
 };
 
-// visit http://localhost:8008/user/1234567890 to see the response
+// visit http://localhost:8008/api/v1/user/1234567890 and http://localhost:8008/api/v1/user/1234567890/funny to see the response
 const localLambdaGroup = new LocalLambdaGroup(multiConfig);
 localLambdaGroup.run();

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,2 +1,3 @@
 export * from './local.lambda';
 export * from './types/index';
+export * from './lambda.group';

--- a/src/lambda.group.ts
+++ b/src/lambda.group.ts
@@ -1,0 +1,45 @@
+import { Context } from 'aws-lambda';
+import express from 'express';
+import { LambdaHandler } from 'index';
+import { DefaultPathParamsPattern, DefaultPort, LocalLambda } from './local.lambda';
+
+
+export interface LambdaConfig {
+  handler: LambdaHandler;
+  context?: Context;
+  enableCORS?: boolean;
+  // default binary content-type headers or override
+  binaryContentTypesOverride?: string[];
+  pathParamsPattern ?: string;
+  requestContext?: Record<string, any>;
+}
+
+
+export interface LocalLambdaGroupConfig {
+  lambdas: LambdaConfig[];
+  port?: number;
+  defaultPath?: string;
+}
+
+export class LocalLambdaGroup {
+  lambdas: LambdaConfig[] = [];
+  app: express.Application;
+  port: number;
+  defaultPath: string;
+
+  constructor(config: LocalLambdaGroupConfig) {
+    this.lambdas = config.lambdas;
+    this.app = express();
+    this.port = config.port ?? DefaultPort;
+    this.defaultPath = config.defaultPath ?? DefaultPathParamsPattern;
+  }
+
+  run(): void {
+    this.lambdas.forEach(lambda => {
+      const localLambda = new LocalLambda(lambda, this.app, this.defaultPath);
+      localLambda.createServer();
+      this.app = localLambda.app;
+    });
+    this.app.listen(this.port, () => console.info(`🚀  Lambda Group Server ready at http://localhost:${this.port} at '${new Date().toLocaleString()}'`));
+  }
+}

--- a/src/lambda.group.ts
+++ b/src/lambda.group.ts
@@ -37,8 +37,7 @@ export class LocalLambdaGroup {
   run(): void {
     this.lambdas.forEach(lambda => {
       const localLambda = new LocalLambda(lambda, this.app, this.defaultPath);
-      localLambda.createServer();
-      this.app = localLambda.app;
+      localLambda.createRoute();
     });
     this.app.listen(this.port, () => console.info(`🚀  Lambda Group Server ready at http://localhost:${this.port} at '${new Date().toLocaleString()}'`));
   }

--- a/src/local.lambda.ts
+++ b/src/local.lambda.ts
@@ -4,7 +4,8 @@ import HTTPMethod from 'http-method-enum';
 import { LambdaHandler, RequestEvent } from './types';
 import express, { Request, Response } from 'express';
 import { flattenArraysInJSON, cloneDeep } from './utils';
-const DefaultPort = 8000;
+import { LambdaConfig } from './lambda.group';
+export const DefaultPort = 8000;
 
 // binary upload content-type headers
 const defaultBinaryContentTypeHeaders = [
@@ -16,7 +17,7 @@ const defaultBinaryContentTypeHeaders = [
   'application/zip',
 ];
 
-const DefaultPathParamsPattern = '/';
+export const DefaultPathParamsPattern = '/';
 
 export class LocalLambda {
   handler: LambdaHandler;
@@ -105,47 +106,7 @@ export class LocalLambda {
 
 }
 
-
-export interface LambdaConfig {
-  handler: LambdaHandler;
-  context?: Context;
-  enableCORS?: boolean;
-  // default binary content-type headers or override
-  binaryContentTypesOverride?: string[];
-  pathParamsPattern ?: string;
-  requestContext?: Record<string, any>;
-}
-
 // extend the LambdaConfig to add port
 export interface LocalLambdaConfig extends LambdaConfig {
   port?: number;
-}
-
-export interface LocalLambdaGroupConfig {
-  lambdas: LambdaConfig[];
-  port?: number;
-  defaultPath?: string;
-}
-
-export class LocalLambdaGroup {
-  lambdas: LambdaConfig[] = [];
-  app: express.Application;
-  port: number;
-  defaultPath: string;
-
-  constructor(config: LocalLambdaGroupConfig) {
-    this.lambdas = config.lambdas;
-    this.app = express();
-    this.port = config.port ?? DefaultPort;
-    this.defaultPath = config.defaultPath ?? DefaultPathParamsPattern;
-  }
-
-  run(): void {
-    this.lambdas.forEach(lambda => {
-      const localLambda = new LocalLambda(lambda, this.app, this.defaultPath);
-      localLambda.createServer();
-      this.app = localLambda.app;
-    });
-    this.app.listen(this.port, () => console.info(`🚀  Lambda Group Server ready at http://localhost:${this.port} at '${new Date().toLocaleString()}'`));
-  }
 }

--- a/src/local.lambda.ts
+++ b/src/local.lambda.ts
@@ -42,7 +42,7 @@ export class LocalLambda {
     this.requestContext = config.requestContext ?? {};
   }
 
-  createServer(): void {
+  createRoute(): void {
     const router = express.Router();
     this.app.use(this.defaultPath, router);
 
@@ -93,7 +93,7 @@ export class LocalLambda {
   }
 
   run(): void {
-    this.createServer();
+    this.createRoute();
     this.app.listen(this.port, () => console.info(`🚀  Server ready at http://localhost:${this.port} at '${new Date().toLocaleString()}'`));
   }
 


### PR DESCRIPTION
This PR refactors the LocalLambda class to use `express.Router()` and adds a new LocalLambdaGroup class for managing multiple lambdas.

The LocalLambda now uses an instance of `express.Router()` for handling requests, and it includes options for setting binary content-type headers, request context, and enable CORS.

In addition, a new LocalLambdaGroup class has been added, which allows for multiple lambdas to be run simultaneously on the same server. It uses the LocalLambda class under the hood to handle each lambda's requests.

Both LocalLambda and LocalLambdaGroup have a `run()` method that starts the server and listens for incoming requests. The LocalLambda instance can also be created separately if needed.

I have tested this implementation thoroughly and all existing tests are passing. Please let me know if there is anything else I can do to help merge this PR.

PS. Based on my assessment, it would be best to hold off merging this PR until after #19 has been merged, as there may still be some additional work required on this PR. Therefore, I recommend deferring the merge until after the other PR has been completed.