### PR TITLE
Remove method from Request Event

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "ts-lambda-local-dev",
-  "version": "2.0.0",
+  "version": "2.1.0",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "ts-lambda-local-dev",
-      "version": "2.0.0",
+      "version": "2.1.0",
       "license": "MIT",
       "dependencies": {
         "@types/aws-lambda": "^8.10.73",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "ts-lambda-local-dev",
-  "version": "2.1.0",
+  "version": "2.0.0",
   "description": "typescript lambda local development server",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",

--- a/src/local.lambda.ts
+++ b/src/local.lambda.ts
@@ -68,7 +68,6 @@ export class LocalLambda {
         const req: RequestEvent = {
           path: parsedUrl.pathname!,
           httpMethod: request.method as HTTPMethod,
-          method: request.method,
           headers: request.headers,
           /* if duplicate queryParameters are present then API Gateway will flatten them into a comma-separated list
              eg: ?a=1&a=2&a=3 will be parsed as { a: [1,2,3] } by url.parse and flattenArraysInJSON will convert it to { a: '1,2,3' } which is the same behavior as API Gateway

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -5,7 +5,6 @@ import { HTTPMethod } from 'http-method-enum';
 export interface RequestEvent {
   requestContext?: any;
   httpMethod?: HTTPMethod;
-  method?: string;
   path: string;
   headers?: IncomingHttpHeaders;
   multiValueHeaders?: { [name: string]: string[] };


### PR DESCRIPTION
The `method` is not used in the API gateway event version 1
https://docs.aws.amazon.com/apigateway/latest/developerguide/http-api-develop-integrations-lambda.html

This created conflict with [middy event normalizer](https://middy.js.org/docs/middlewares/http-event-normalizer) because it chooses the [`vpc` mode](https://github.com/middyjs/middy/blob/main/packages/http-event-normalizer/index.js#L33) and [removes the query parameters](https://github.com/middyjs/middy/blob/0c366128a7090e6e2b1a31bb6968e9a0f192bc89/packages/http-event-normalizer/index.js#L17)